### PR TITLE
Master version equivalence to compass

### DIFF
--- a/compass-rails.gemspec
+++ b/compass-rails.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = CompassRails::VERSION
 
-  gem.add_dependency 'compass', '~> 0.12.0'
+  gem.add_dependency 'compass', '~> 0.13.alpha'
 
 end


### PR DESCRIPTION
Modify compass-rails' master compass dependency to match the master version of compass.
