### PR TITLE
Updates readme with step to edit application config when installing plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,15 @@ then run:
 
     $ bundle
     $ bundle exec compass install susy
+    
+if you are using the rails configuration files you should add:
+
+```ruby
+config.compass.require "susy"
+```
+
+to your application.rb configuration file.
+
 
 ### Notes On Sprockets Directives
 


### PR DESCRIPTION
I was receiving errors when attempting to include the susy plugin in my application. When using the rails configuration files instead of the compass file you must include config.compass.require "susy" or compass can't locate the plugin.
