### PR TITLE
allow compass-rails without asset pipeline on Rails 3.2

### DIFF
--- a/lib/compass-rails/railties/3_1.rb
+++ b/lib/compass-rails/railties/3_1.rb
@@ -88,12 +88,16 @@ module CompassRails
   class Railtie < Rails::Railtie
 
     initializer "compass.initialize_rails", :group => :all do |app|
-      require 'compass-rails/patches/3_1'
-      # Configure compass for use within rails, and provide the project configuration
-      # that came via the rails boot process.
-      CompassRails.check_for_double_boot!
-      Compass.discover_extensions!
-      CompassRails.configure_rails!(app)
+      if CompassRails.asset_pipeline_enabled?
+        require 'compass-rails/patches/3_1'
+        # Configure compass for use within rails, and provide the project configuration
+        # that came via the rails boot process.
+        CompassRails.check_for_double_boot!
+        Compass.discover_extensions!
+        CompassRails.configure_rails!(app)
+      else
+        CompassRails.initialize!(app.config.compass)
+      end
     end
   end
 end

--- a/test/helpers/rails_helper.rb
+++ b/test/helpers/rails_helper.rb
@@ -19,7 +19,7 @@ module CompassRails
           RAILS_2   => GEMFILES_DIR.join("rails2.gemfile").to_s
         }
         
-        GENERTOR_OPTIONS = {
+        GENERATOR_OPTIONS = {
           RAILS_3_2 => ['-q', '-G', '-O', '--skip-bundle'],
           RAILS_3_1 => ['-q', '-G', '-O', '--skip-bundle'],
           RAILS_3   => ['-q', '-G', '-O', '--skip-bundle'],
@@ -42,18 +42,18 @@ module CompassRails
     # with the rails libraries. This will allow testing against multiple versions of rails
     # by manipulating the load path.
     def generate_rails_app(name, version, options=[])
-      options += GENERTOR_OPTIONS[version]
+      options += GENERATOR_OPTIONS[version]
       rails_command([GENERATOR_COMMAND[version], name, *options], version)
     end
 
-    def within_rails_app(named, version, &block)
+    def within_rails_app(named, version, asset_pipeline_enabled = true, &block)
       dir = "#{named}-#{version}"
       rm_rf File.join(WORKING_DIR, dir)
       mkdir_p WORKING_DIR
       cd(WORKING_DIR) do
-        generate_rails_app(dir, version)
+        generate_rails_app(dir, version, asset_pipeline_enabled ? [] : ["-S"])
         cd(dir) do
-          yield RailsProject.new(File.join(WORKING_DIR, dir), version)
+          yield RailsProject.new(File.join(WORKING_DIR, dir), version, asset_pipeline_enabled)
         end
       end
       rm_rf File.join(WORKING_DIR, dir)

--- a/test/helpers/rails_project.rb
+++ b/test/helpers/rails_project.rb
@@ -16,11 +16,12 @@ module CompassRails
       BOOT_FILE = 'config/boot.rb'
 
 
-      attr_reader :directory, :version
+      attr_reader :directory, :version, :asset_pipeline_enabled
 
-      def initialize(directory, version)
+      def initialize(directory, version, asset_pipeline_enabled = true)
         @directory = Pathname.new(directory)
         @version = version
+        @asset_pipeline_enabled = asset_pipeline_enabled
         configure_for_bundler!
       end
 
@@ -41,7 +42,11 @@ module CompassRails
       def screen_file
         case version
         when RAILS_3_1, RAILS_3_2
-          return directory.join('app', 'assets', 'stylesheets', 'screen.css.scss')
+          if asset_pipeline_enabled
+            return directory.join('app', 'assets', 'stylesheets', 'screen.css.scss')
+          else
+            return directory.join('app', 'assets', 'stylesheets','screen.scss')
+          end
         when RAILS_2, RAILS_3
           return directory.join('app', 'assets', 'stylesheets','screen.scss')
         end

--- a/test/integrations/rails_32_without_pipeline_test.rb
+++ b/test/integrations/rails_32_without_pipeline_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+class Rails32WithoutPipelineTest < Test::Unit::TestCase
+  include CompassRails::Test::RailsHelpers
+  RAILS_VERSION = RAILS_3_2
+
+  def test_rails_app_created
+    within_rails_app('test_railtie', RAILS_VERSION, false) do |project|
+      assert project.boots?
+    end
+  end
+
+  def test_installs_compass
+    within_rails_app('test_railtie', RAILS_VERSION, false) do |project|
+      project.run_compass('init')
+      assert project.has_config?
+      assert project.has_screen_file?
+      assert project.has_compass_import?
+    end
+  end
+
+  def test_compass_compile
+    within_rails_app('test_railtie', RAILS_VERSION, false) do |project|
+      project.run_compass('init')
+      project.run_compass('compile')
+      assert project.directory.join('public/stylesheets/screen.css').exist?
+    end
+  end
+
+  def test_install_blueprint
+    within_rails_app('test_railtie', RAILS_VERSION, false) do |project|
+      project.run_compass('init')
+      project.run_compass('install blueprint --force')
+      assert project.directory.join('app/assets/stylesheets/partials').directory?
+    end
+  end
+
+end


### PR DESCRIPTION
We are using compass-rails on a Rails 3.2 project. Since this is an upgrade, we didn't want to immediately use the asset pipeline.

This change allows Rails 3.2 to use compass-rails without the asset pipeline. It basically makes the railtie functionality load the Rails 3.0.x logic.
