### PR TITLE
Make sure ActionController is loaded before trying to patch it

### DIFF
--- a/lib/compass-rails/railties/2_3.rb
+++ b/lib/compass-rails/railties/2_3.rb
@@ -1,5 +1,6 @@
 #rails 2.x doesn't have railties so gona do this the long way
 require "sass/plugin/rack" #unless defined?(Sass::Plugin::Rack)
+require "action_controller"
 
 module ActionController
   class Base


### PR DESCRIPTION
Hi!  In our Rails 2.3 app we're using Compass, and after upgrading to more recent versions we discovered that "bundle exec compass" commands no longer work.  This seems to be because Compass is requiring everything in bundler's :assets group, but not Rails itself.

This was the simplest fix I could come up with for the issue.
