### PR TITLE
fix generated_image_url when generated_images_dir is set

### DIFF
--- a/lib/compass-rails/patches/3_1.rb
+++ b/lib/compass-rails/patches/3_1.rb
@@ -2,6 +2,11 @@ require 'compass-rails/patches/static_compiler'
 
 module Sass::Script::Functions
   def generated_image_url(path, only_path = nil)
+    path = if Compass.configuration.generated_images_dir
+             full_path = File.join(Compass.configuration.generated_images_dir, path.value)
+             Sass::Script::String.new full_path.sub(File.join('app', 'assets', 'images'), "")[1..-1]
+           end
+
     asset_url(path, Sass::Script::String.new("image"))
   end
 end
@@ -9,7 +14,7 @@ end
 
 module Compass::RailsImageFunctionPatch
   private
-  
+
   def image_path_for_size(image_file)
     begin
       file = ::Rails.application.assets.find_asset(image_file)


### PR DESCRIPTION
sprite-url breaks when generated_images_dir is set. this is my fix.

use compass "~> 0.13.alpha.2" to test.
