### PR TITLE
Add in cachebusting for sprites

### DIFF
--- a/lib/compass-rails/patches/4_0.rb
+++ b/lib/compass-rails/patches/4_0.rb
@@ -2,6 +2,7 @@ require 'compass-rails/patches/sass_importer'
 require 'compass-rails/patches/sprite_importer'
 module Sass::Script::Functions
   def generated_image_url(path, only_path = nil)
+    options[:sprockets][:environment].send(:trail).instance_variable_get(:@entries).delete(File.join(Rails.root, Compass.configuration.generated_images_dir))
     asset_url(path)
   end
 end


### PR DESCRIPTION
As commented on in https://github.com/Compass/compass-rails/issues/94, this adds in a reset for the file cache for generated images. This is needed to allow sprockets to find a newly generated spritesheet for the first request.
