### PR TITLE
Revert "fix generated_image_url when generated_images_dir is set"

### DIFF
--- a/lib/compass-rails/patches/3_1.rb
+++ b/lib/compass-rails/patches/3_1.rb
@@ -3,11 +3,6 @@ require 'compass-rails/patches/static_compiler'
 
 module Sass::Script::Functions
   def generated_image_url(path, only_path = nil)
-    path = if Compass.configuration.generated_images_dir
-             full_path = File.join(Compass.configuration.generated_images_dir, path.value)
-             Sass::Script::String.new full_path.sub(File.join('app', 'assets', 'images'), "")[1..-1]
-           end
-
     asset_url(path, Sass::Script::String.new("image"))
   end
 end


### PR DESCRIPTION
This reverts commit 5ed70d60254645a46ddf8ed1cf78a57adc917815.

Conflicts:
    lib/compass-rails/patches/3_1.rb
