### PR TITLE
Backport to 1-1-stable: Remove noisy puts

### DIFF
--- a/lib/compass-rails/patches/sprite_importer.rb
+++ b/lib/compass-rails/patches/sprite_importer.rb
@@ -13,7 +13,6 @@ module CompassRails
     def find(uri, options)
       if old = super(uri, options)
         self.class.files(uri).each do |file|
-          puts file.inspect
           relative_path = Pathname.new(file).relative_path_from(Pathname.new(root))
           begin
             pathname = context.resolve(relative_path)


### PR DESCRIPTION
This caused very noisy log outputs and was obfuscating our
test logs
