### PR TITLE
Fixed method rails_loaded? for when Rails is defined but no application is actually loaded

### DIFF
--- a/lib/compass-rails.rb
+++ b/lib/compass-rails.rb
@@ -13,7 +13,6 @@ module CompassRails
 
     def load_rails
       return true if rails_loaded?
-      return if defined?(::Rails) && ::Rails.respond_to?(:application) && !::Rails.application.nil?
 
       rails_config_path = Dir.pwd
       until File.exists?(File.join(rails_config_path, 'config', 'application.rb')) do
@@ -75,7 +74,7 @@ module CompassRails
     end
 
     def rails_loaded?
-      defined?(::Rails)
+      defined?(::Rails) && ::Rails.respond_to?(:application) && !::Rails.application.nil?
     end
 
     def rails_version
@@ -216,7 +215,7 @@ module CompassRails
     end
 
   def asset_pipeline_enabled?
-    return false unless rails_loaded? && ::Rails.respond_to?(:application) && !::Rails.application.nil?
+    return false unless rails_loaded?
     rails_config = ::Rails.application.config
     if rails_config.respond_to?(:assets)
       rails_config.assets.enabled != false
@@ -243,5 +242,3 @@ Compass.add_configuration(CompassRails.boot_config)
 require "compass-rails/patches"
 require "compass-rails/railties"
 require "compass-rails/installer"
-
-


### PR DESCRIPTION
This is like #127 but only a tiny patch and fixes the issues I'm having with:

```
NoMethodError on line ["221"] of /Users/parndt/.gem/ruby/2.1.1/gems/compass-rails-1.1.3/lib/compass-rails.rb: undefined method `config' for nil:NilClass
  /Users/parndt/.gem/ruby/2.1.1/gems/compass-rails-1.1.3/lib/compass-rails.rb:128:in `configuration'
  /Users/parndt/.gem/ruby/2.1.1/gems/compass-0.12.2/lib/compass/configuration/helpers.rb:44:in `configuration_for'
  /Users/parndt/.gem/ruby/2.1.1/gems/compass-0.12.2/lib/compass/configuration/helpers.rb:22:in `add_configuration'
  /Users/parndt/.gem/ruby/2.1.1/gems/compass-0.12.2/lib/compass/configuration/helpers.rb:107:in `add_project_configuration'
  /Users/parndt/.gem/ruby/2.1.1/gems/compass-0.12.2/lib/compass/commands/project_base.rb:31:in `add_project_configuration'
  /Users/parndt/.gem/ruby/2.1.1/gems/compass-0.12.2/lib/compass/commands/project_base.rb:25:in `configure!'
  /Users/parndt/.gem/ruby/2.1.1/gems/compass-0.12.2/lib/compass/commands/project_base.rb:15:in `initialize'
  /Users/parndt/.gem/ruby/2.1.1/gems/compass-0.12.2/lib/compass/commands/update_project.rb:37:in `initialize'
  /Users/parndt/.gem/ruby/2.1.1/gems/compass-0.12.2/lib/compass/exec/sub_command_ui.rb:42:in `new'
  /Users/parndt/.gem/ruby/2.1.1/gems/compass-0.12.2/lib/compass/exec/sub_command_ui.rb:42:in `perform!'
  /Users/parndt/.gem/ruby/2.1.1/gems/compass-0.12.2/lib/compass/exec/sub_command_ui.rb:15:in `run!'
  /Users/parndt/.gem/ruby/2.1.1/gems/compass-0.12.2/bin/compass:30:in `block in <top (required)>'
  /Users/parndt/.gem/ruby/2.1.1/gems/compass-0.12.2/bin/compass:44:in `call'
  /Users/parndt/.gem/ruby/2.1.1/gems/compass-0.12.2/bin/compass:44:in `<top (required)>'
  /Users/parndt/.gem/ruby/2.1.1/bin/compass:23:in `load'
  /Users/parndt/.gem/ruby/2.1.1/bin/compass:23:in `<main>'

```
