### PR TITLE
Use Rainbow API to fix undefined method errors

### DIFF
--- a/test/helpers/command_helper.rb
+++ b/test/helpers/command_helper.rb
@@ -43,7 +43,7 @@ module CompassRails
       BUNDLER_COMMAND = 'bundle'
 
       def run_command(command, gemfile=nil)
-        debug("Running: #{command} with gemfile: #{gemfile}".foreground(:cyan))
+        debug(Rainbow("Running: #{command} with gemfile: #{gemfile}").foreground(:cyan))
         capture_all_output { CompassRails::Test::CommandRunner.new(command, gemfile).run }
       end
 
@@ -116,5 +116,3 @@ class CompassRails::Test::CommandRunner
     @original_env.each { |key, value| ENV[key] = value }
   end
 end
-
-

--- a/test/helpers/debug_helper.rb
+++ b/test/helpers/debug_helper.rb
@@ -3,7 +3,7 @@ module CompassRails
     module DebugHelper
 
       def debug(message)
-       puts "#{message}\n".bright #if ENV['DEBUG']
+       puts Rainbow("#{message}\n").bright #if ENV['DEBUG']
        $stdout.flush
       end
 

--- a/test/helpers/file_helper.rb
+++ b/test/helpers/file_helper.rb
@@ -4,19 +4,19 @@ module CompassRails
       include DebugHelper
 
       def mkdir_p(dir)
-        debug("Creating Directory: #{dir}".foreground(:green))
+        debug(Rainbow("Creating Directory: #{dir}").foreground(:green))
         ::FileUtils.mkdir_p dir
         assert File.directory?(dir), "mkdir_p: #{dir} failed"
       end
 
       def rm_rf(path)
-        debug("Removing: #{path}".foreground(:red))
+        debug(Rainbow("Removing: #{path}").foreground(:red))
         ::FileUtils.rm_rf(path)
         assert !File.directory?(path), "rm_rf: #{path} failed"
       end
 
       def cd(path, &block)
-        debug("Entered: #{path}".foreground(:yellow))
+        debug(Rainbow("Entered: #{path}").foreground(:yellow))
         Dir.chdir(path, &block)
       end
 
@@ -27,7 +27,7 @@ module CompassRails
       end
 
       def touch(file)
-        debug("Touching File: #{file}".foreground(:green))
+        debug(Rainbow("Touching File: #{file}").foreground(:green))
         ::FileUtils.touch(file)
       end
 

--- a/test/helpers/rails_helper.rb
+++ b/test/helpers/rails_helper.rb
@@ -34,7 +34,7 @@ module CompassRails
         }
 
     def rails_command(options, version)
-      debug("Running Rails command with: rails #{options.join(' ')}".foreground(:cyan))
+      debug(Rainbow("Running Rails command with: rails #{options.join(' ')}").foreground(:cyan))
       run_command("rails #{options.join(' ')}", GEMFILES[version])
     end
 

--- a/test/helpers/rails_project.rb
+++ b/test/helpers/rails_project.rb
@@ -109,7 +109,7 @@ module CompassRails
 
       def add_to_gemfile(name, requirements)
         gemfile = directory.join(GEMFILE)
-        debug("Adding gem #{name} to file: #{gemfile}".foreground(:green))
+        debug(Rainbow("Adding gem #{name} to file: #{gemfile}").foreground(:green))
         if requirements
           gem_string = "  gem '#{name}', #{requirements}\n"
         else


### PR DESCRIPTION
Using the API per https://github.com/sickill/rainbow#example

We could also `require 'rainbow/ext/string'` but it's easy enough to wrap each usage rather than adding lots of methods to `String`.
