### PR TITLE
Lock sprockets to 2.11.0 until a fix is available & Bump version

### DIFF
--- a/compass-rails.gemspec
+++ b/compass-rails.gemspec
@@ -17,5 +17,6 @@ Gem::Specification.new do |gem|
   gem.license       = "MIT"
 
   gem.add_dependency 'compass', '>= 0.12.2'
+  gem.add_dependency 'sprockets', '~> 2.8', '<= 2.11.0'  
 
 end

--- a/lib/compass-rails/version.rb
+++ b/lib/compass-rails/version.rb
@@ -1,5 +1,5 @@
 module CompassRails
   unless defined?(::CompassRails::VERSION)
-    VERSION = "1.1.6"
+    VERSION = "1.1.7"
   end
 end


### PR DESCRIPTION
If we don't do this then all systems that update to 2.12 will break.

related to https://github.com/Compass/compass-rails/issues/144
