### PR TITLE
Rails.application.assets.trail isn't necessarily a Hike::Index; don't break if it's a Hike::Trail

### DIFF
--- a/lib/compass-rails/railties/4_0.rb
+++ b/lib/compass-rails/railties/4_0.rb
@@ -62,7 +62,7 @@ class Rails::Railtie::Configuration
 
           # Clear entries in Hike::Index for this sprite's directory.
           # This makes sure the asset can be found by find_assets
-          Rails.application.assets.send(:trail).instance_variable_get(:@entries).delete(File.dirname(filename))
+          Rails.application.assets.send(:trail).instance_variable_get(:@entries).try(:delete, File.dirname(filename))
 
           pathname      = Pathname.new(filename)
           logical_path  = pathname.relative_path_from(Pathname.new(Compass.configuration.images_path))


### PR DESCRIPTION
Unfortunately I'm having trouble figuring out a reproducible case for this; however, running our app's test suite on Tddium, we ran into an error during asset precompilation.  Specifically, the `@entries` instance variable didn't seem to exist on `Rails.application.assets.send(:trail)`.

Digging in further, this seems to be because sometimes that method will return a Hike::Trail rather than a Hike::Index.  I'm not sure what is causing this to be the case in certain circumstances but not others (I couldn't reproduce this locally, indicating that on my laptop, for some reason, it is always a Hike::Index, but on Tddium it isn't).

But, I do have evidence of this happening in the wild, so here is a simple patch to work around the issue.  I don't believe the cache-busting will be necessary if it's a Hike::Trail, because those are uncached anyhow.
