### PR TITLE
Delete stats for filename in case they were cached

### DIFF
--- a/lib/compass-rails/railties/4_0.rb
+++ b/lib/compass-rails/railties/4_0.rb
@@ -28,7 +28,9 @@ module CompassRails
 
             # Clear entries in Hike::Index for this sprite's directory.
             # This makes sure the asset can be found by find_assets
-            Rails.application.assets.send(:trail).instance_variable_get(:@entries).delete(File.dirname(filename))
+            trail = Rails.application.assets.send(:trail)
+            trail.instance_variable_get(:@entries).delete(File.dirname(filename))
+            trail.instance_variable_get(:@stats).delete(filename)
 
             pathname      = Pathname.new(filename)
             logical_path  = pathname.relative_path_from(Pathname.new(Compass.configuration.images_path))


### PR DESCRIPTION
This PR fixes issue  #158
Hike 1.2.3 not only caches the path entries, but also caches the file stats. This causes problem when the sprockets cache exists, and you recompile assets (because compass regenerates the sprite but hike already cached the app/assets/images path).

I've tested with:
- compass (0.12.6)
- compass-rails (2.0.0.pre d8ca1ef)
- hike (1.2.3)
- sass (3.2.19)
- sass-rails (4.0.3)
- sprockets (2.11.0)
- sprockets-rails (2.1.3)
