### PR TITLE
Use correct Compass version.

### DIFF
--- a/compass-rails.gemspec
+++ b/compass-rails.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = CompassRails::VERSION
   gem.license       = "MIT"
 
-  gem.add_dependency 'compass', '>= 0.12.2'
+  gem.add_dependency 'compass', '>= 0.12.2', "<= 1.0.0"
   gem.add_dependency 'sprockets', '<= 2.11.0'
 
 end


### PR DESCRIPTION
I ran into issues when installing compass-rails as it threw errors about the haml version needing to be updated to 3.1 when I was on haml 3.1. If I updated my haml version further, it then threw an error about modifying Frozen Arrays. I spent 2 hours tracking down that compass-rails was installing compass v1.0.0. If I removed that installed compass v0.12.6 everything worked fine.

So this PR is to block using compass v1.0.0. 
