### PR TITLE
Be more careful before executing nil.delete on trail cache

### DIFF
--- a/lib/compass-rails/railties/4_0.rb
+++ b/lib/compass-rails/railties/4_0.rb
@@ -29,8 +29,14 @@ module CompassRails
             # Clear entries in Hike::Index for this sprite's directory.
             # This makes sure the asset can be found by find_assets
             trail = Rails.application.assets.send(:trail)
-            trail.instance_variable_get(:@entries).delete(File.dirname(filename))
-            trail.instance_variable_get(:@stats).delete(filename)
+
+            # Fix instance where @entires or @stats does not have @entries or @stats
+            # Might be a result of lib/compass-rails/patches/4_0.rb #cachebust_generated_images already purging trail cache
+            current_trail_entries = trail.instance_variable_get(:@entries)
+            current_trail_entries.delete(File.dirname(filename)) unless current_trail_entries.nil?
+            
+            current_trail_stats = trail.instance_variable_get(:@stats)
+            current_trail_stats.delete(filename) unless current_trail_stats.nil?
 
             pathname      = Pathname.new(filename)
             logical_path  = pathname.relative_path_from(Pathname.new(Compass.configuration.images_path))


### PR DESCRIPTION
Might be the case where someone else addressed a similar problem as I did in #166 and ended up trying to delete the same (or related object) twice.

Effectively at some point, we get a nil, and nil#delete throws an exception.

Not knowing who has the better bug fix, here's one way to ensure we only execute #delete when we actually have an object.
