### PR TITLE
Allow minor version updates on sprockets 2.11

### DIFF
--- a/compass-rails.gemspec
+++ b/compass-rails.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |gem|
   gem.license       = "MIT"
 
   gem.add_dependency 'compass', '>= 0.12.2', "<= 1.0.0"
-  gem.add_dependency 'sprockets', '<= 2.11.0'
+  gem.add_dependency 'sprockets', '< 2.12'
 
 end


### PR DESCRIPTION
Per [CVE-2014-7819](https://groups.google.com/forum/#!topic/rubyonrails-security/doAVp0YaTqY), I'm attempting to upgrade to sprockets 2.11.3. I believe the gemspec locks versions less or eqaul to than 2.11.0. 

This change purposes excepting any sprockets version less than 2.12.

Please let me know if you have any questions/feedback.
