### PR TITLE
Fixed incorrect path generation for sprites in Rails 4

### DIFF
--- a/lib/compass-rails/patches/3_1.rb
+++ b/lib/compass-rails/patches/3_1.rb
@@ -2,7 +2,7 @@ require 'compass-rails/patches/compass'
 require 'compass-rails/patches/static_compiler'
 
 Compass::Core::SassExtensions::Functions::Urls::GeneratedImageUrl.module_eval do
-  def generated_image_url(path, only_path = nil)
-    asset_url(path, Sass::Script::String.new("image"))
+  def generated_image_url(path, cache_buster = Sass::Script::Bool.new(false))
+    asset_url(path, Sass::Script::String.new('image'))
   end
 end

--- a/lib/compass-rails/patches/4_0.rb
+++ b/lib/compass-rails/patches/4_0.rb
@@ -3,34 +3,31 @@ require 'compass-rails/patches/sass_importer'
 require 'compass-rails/patches/sprite_importer'
 
 Compass::Core::SassExtensions::Functions::Urls::GeneratedImageUrl.module_eval do
-  def generated_image_url(path, only_path = nil)
-    pathobject = Pathname.new(path.to_s)
-    subdirectory = pathobject.dirname.to_s
-
-    cachebust_generated_images(path, subdirectory)
+  def generated_image_url(path, cache_buster = Sass::Script::Bool.new(false))
+    cachebust_generated_images(path)
     asset_url(path)
   end
 
-  def cachebust_generated_images(image_path, subdirectory = nil)
-    generated_images_path = Rails.root.join(Compass.configuration.generated_images_dir).to_s
-    if subdirectory.nil?
-      bust_cache_path = generated_images_path
-    else
-      bust_cache_path = generated_images_path + "/" + subdirectory
-    end
-    bust_image_stat_path = generated_images_path + "/" + image_path.to_s
+  def cachebust_generated_images(path)
+    generated_images_dir = Compass.configuration.generated_images_dir
+    generated_images_dir = Rails.root.join(generated_images_dir)
 
-    sprockets_entries = options[:sprockets][:environment].send(:trail).instance_variable_get(:@entries)
+    sprockets_env     = options[:sprockets][:environment]
+    sprockets_trail   = sprockets_env.send(:trail)
+    sprockets_entries = sprockets_trail.instance_variable_get(:@entries) || {}
+    sprockets_stats   = sprockets_trail.instance_variable_get(:@stats) || {}
 
-    # sprockets_entries.delete(generated_images_path) if sprockets_entries.has_key? generated_images_path
-    if sprockets_entries.has_key? generated_images_path
-      # sprockets_entries.delete(generated_images_path)
+    if sprockets_entries.key?(generated_images_dir.to_s)
+      path = path.value
+      dir  = File.dirname(path)
 
       # Delete the entries (directories) which cache the files/dirs in a directory
-      options[:sprockets][:environment].send(:trail).instance_variable_get(:@entries).delete(bust_cache_path)
+      entry = generated_images_dir.join(dir).to_s
+      sprockets_entries.delete(entry)
 
       # Delete the stats (file/dir info) which cache the what kind of file/dir each image is
-      options[:sprockets][:environment].send(:trail).instance_variable_get(:@stats).delete(bust_image_stat_path)
+      stat = generated_images_dir.join(path).to_s
+      sprockets_stats.delete(stat)
     end
   end
 end


### PR DESCRIPTION
Before:

``` ruby
if subdirectory.nil?
  bust_cache_path = generated_images_path
else
  bust_cache_path = generated_images_path + "/" + subdirectory
end
```

`subdirectory` will never be `nil?` there.
It will be `.` in case `path` is `icons-sXXXXXXXXXX.png` and `bust_cache_path` becomes `app/assets/images/.`

Moving the sprited images into a deeper subfolder works around the problem, `subdirectory` becomes `folder_name` instead of `.`.

Fixes #94, #162, #187, #188
