### PR TITLE
Only support up to sass-rails 4.0.0

### DIFF
--- a/compass-rails.gemspec
+++ b/compass-rails.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'compass', '>= 0.12.2'
   gem.add_dependency 'sprockets', '<= 2.11.0'
-  gem.add_dependency 'sass-rails', '<= 4.0.0'
+  gem.add_dependency 'sass-rails', '<= 5.0.1'
 
 end


### PR DESCRIPTION
Compass Rails expects to monkey patch `sass-rails`'s `SassTemplate` in very specific ways that break on pretty much any patch release.

https://github.com/Compass/compass-rails/blob/master/lib/compass-rails/patches/sass_importer.rb

I would recommend completely locking down the supported patch version to ensure the patches are always applied correctly. Then advance the version only after testing.

I think this should help resolve upgrade pain when people try to upgrade either sprockets or sass-rails and everything breaks because of an out of date compass-rails patch.

Thanks!

/cc @rafaelfranca 
