### PR TITLE
Update patch for sass-rails 5.0.0

### DIFF
--- a/lib/compass-rails/patches/sass_importer.rb
+++ b/lib/compass-rails/patches/sass_importer.rb
@@ -8,17 +8,17 @@ klass.class_eval do
   def evaluate(context, locals, &block)
     # Use custom importer that knows about Sprockets Caching
     cache_store = Sprockets::SassCacheStore.new(context.environment)
-    paths  = context.environment.paths.map { |path| CompassRails::SpriteImporter.new(context, path) }
-    paths += context.environment.paths.map { |path| self.class.parent::SassImporter.new(context, path) }
-    paths += ::Rails.application.config.sass.load_paths
 
+    paths  = context.environment.paths.map { |path| CompassRails::SpriteImporter.new(context, path) }
+    paths += context.environment.paths.map { |path| self.class.parent::SassImporter.new(path) }
+    paths += ::Rails.application.config.sass.load_paths
 
     options = CompassRails.sass_config.merge( {
       :filename => eval_file,
       :line => line,
       :syntax => syntax,
       :cache_store => cache_store,
-      :importer => self.class.parent::SassImporter.new(context, context.pathname),
+      :importer => self.class.parent::SassImporter.new(context.pathname.to_s),
       :load_paths => paths,
       :sprockets => {
         :context => context,
@@ -28,9 +28,7 @@ klass.class_eval do
 
     ::Sass::Engine.new(data, options).render
   rescue ::Sass::SyntaxError => e
-    # Annotates exception message with parse line number
     context.__LINE__ = e.sass_backtrace.first[:line]
     raise e
   end
-end    
-
+end


### PR DESCRIPTION
sass-rails 5.0.0 changed SassImporter arguments. I update this change into compass-rails's patch.
