### PR TITLE
Remove duplicate compass-rails gem declaration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :assets do
-  gem "compass-rails", :path=>"."
   gem 'compass-blueprint'
 end
 

--- a/gemfiles/rails31.gemfile
+++ b/gemfiles/rails31.gemfile
@@ -2,21 +2,21 @@
 
 source "https://rubygems.org"
 
-gem "rb-fsevent", :require=>false
-gem "ruby_gntp", :require=>false
+gem "rb-fsevent", :require => false
+gem "ruby_gntp", :require => false
 gem "guard"
 gem "guard-test"
 gem "rails", "3.1.3"
 gem "sass-rails"
 
 group :assets do
-  gem "compass-rails", :path=>".."
   gem "compass-blueprint"
 end
+
 group :test do
   gem "mocha"
-  gem "appraisal", :git=>"https://github.com/scottdavis/appraisal.git"
+  gem "appraisal"
   gem "rainbow"
 end
 
-gemspec :path=>"../"
+gemspec :path => "../"

--- a/gemfiles/rails32.gemfile
+++ b/gemfiles/rails32.gemfile
@@ -2,21 +2,21 @@
 
 source "https://rubygems.org"
 
-gem "rb-fsevent", :require=>false
-gem "ruby_gntp", :require=>false
+gem "rb-fsevent", :require => false
+gem "ruby_gntp", :require => false
 gem "guard"
 gem "guard-test"
 gem "rails", "~> 3.2"
 gem "sass-rails"
 
 group :assets do
-  gem "compass-rails", :path=>".."
   gem "compass-blueprint"
 end
+
 group :test do
   gem "mocha"
-  gem "appraisal", :git=>"https://github.com/scottdavis/appraisal.git"
+  gem "appraisal"
   gem "rainbow"
 end
 
-gemspec :path=>"../"
+gemspec :path => "../"

--- a/gemfiles/rails40.gemfile
+++ b/gemfiles/rails40.gemfile
@@ -2,21 +2,21 @@
 
 source "https://rubygems.org"
 
-gem "rb-fsevent", :require=>false
-gem "ruby_gntp", :require=>false
+gem "rb-fsevent", :require => false
+gem "ruby_gntp", :require => false
 gem "guard"
 gem "guard-test"
 gem "rails", "~> 4.0.0"
 gem "sass-rails"
 
 group :assets do
-  gem "compass-rails", :path=>".."
   gem "compass-blueprint"
 end
+
 group :test do
   gem "mocha"
-  gem "appraisal", :git=>"https://github.com/scottdavis/appraisal.git"
+  gem "appraisal"
   gem "rainbow"
 end
 
-gemspec :path=>"../"
+gemspec :path => "../"


### PR DESCRIPTION
There is already a gemspec declaration, so there's no need for an extra
compass-rails delclaration in the Gemfile.

This is a step towards trying to to fix the broken Travis-CI build.
https://travis-ci.org/Compass/compass-rails/jobs/37223372

```
Your Gemfile lists the gem compass-rails (>= 0) more than once.
You should probably keep only one of them.
While it's not a problem now, it could cause errors if you change the version of just one of them later.
You cannot specify the same gem twice coming from different sources.
You specified that compass-rails (>= 0) should come from source at . and source
at ../
```
