### PR TITLE
Get the real arity of the initialize method for sass importer

### DIFF
--- a/lib/compass-rails/patches/sass_importer.rb
+++ b/lib/compass-rails/patches/sass_importer.rb
@@ -37,7 +37,7 @@ klass.class_eval do
   private
 
   def sass_importer_artiy
-    @sass_importer_artiy ||= self.class.parent::SassImporter.method(:initialize).arity
+    @sass_importer_artiy ||= self.class.parent::SassImporter.instance_method(:initialize).arity
   end
 
 


### PR DESCRIPTION
instance_method is needed here when requiring the arity of a constructor
