### PR TITLE
Fix sprite importer serialization

### DIFF
--- a/lib/compass-rails/patches/sass_importer.rb
+++ b/lib/compass-rails/patches/sass_importer.rb
@@ -14,7 +14,7 @@ klass.class_eval do
         Sprockets::SassProcessor::CacheStore.new(sprockets_cache_store, context.environment)
       end
 
-    paths  = context.environment.paths.map { |path| CompassRails::SpriteImporter.new(context, path) }
+    paths  = context.environment.paths.map { |path| CompassRails::SpriteImporter.new(path) }
     paths += context.environment.paths.map { |path| sass_importer(context, path) }
     paths += ::Rails.application.config.sass.load_paths
 

--- a/lib/compass-rails/patches/sprite_importer.rb
+++ b/lib/compass-rails/patches/sprite_importer.rb
@@ -3,7 +3,7 @@ require 'compass/sprite_importer'
 
 module CompassRails
   class SpriteImporter < Compass::SpriteImporter
-    attr_reader :context, :root
+    attr_reader :root
 
     def initialize(root)
       @root = root
@@ -11,10 +11,10 @@ module CompassRails
 
     def find(uri, options)
       if old = super(uri, options)
+        context = options[:sprockets][:context]
         self.class.files(uri).each do |file|
           relative_path = Pathname.new(file).relative_path_from(Pathname.new(root))
           begin
-            context = options[:sprockets][:context]
             pathname = context.resolve(relative_path)
             context.depend_on_asset(pathname)
           rescue Sprockets::FileNotFound

--- a/lib/compass-rails/patches/sprite_importer.rb
+++ b/lib/compass-rails/patches/sprite_importer.rb
@@ -5,8 +5,7 @@ module CompassRails
   class SpriteImporter < Compass::SpriteImporter
     attr_reader :context, :root
 
-    def initialize(context, root)
-      @context = context
+    def initialize(root)
       @root = root
     end
 
@@ -15,6 +14,7 @@ module CompassRails
         self.class.files(uri).each do |file|
           relative_path = Pathname.new(file).relative_path_from(Pathname.new(root))
           begin
+            context = options[:sprockets][:context]
             pathname = context.resolve(relative_path)
             context.depend_on_asset(pathname)
           rescue Sprockets::FileNotFound


### PR DESCRIPTION
Fix the `can't dump anonymous class` warnings described in https://github.com/Compass/compass-rails/issues/219 by ensuring CompassRails::SpriteImporter can be serialized, by removing the `@context` instance variable in favor of `options[:sprockets][:context]` (as was done in https://github.com/rails/sass-rails/pull/292).