### PR TITLE
Sprockets 3 beta (WIP)

### DIFF
--- a/compass-rails.gemspec
+++ b/compass-rails.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |gem|
   gem.license       = "MIT"
 
   gem.add_dependency 'compass', '~> 1.0.0'
-  gem.add_dependency 'sprockets', '< 2.13'
+  gem.add_dependency 'sprockets', '~> 3.0.0.beta.8'
   gem.add_dependency 'sass-rails', '<= 5.0.1'
 end

--- a/lib/compass-rails/patches/sass_importer.rb
+++ b/lib/compass-rails/patches/sass_importer.rb
@@ -7,11 +7,11 @@ end
 klass.class_eval do
   def evaluate(context, locals, &block)
     # Use custom importer that knows about Sprockets Caching
-    cache_store = 
-      if defined?(Sprockets::SassCacheStore)
-        Sprockets::SassCacheStore.new(context.environment)
-      else
+    cache_store =
+      if defined?(Sprockets::SassProcessor::CacheStore)
         Sprockets::SassProcessor::CacheStore.new(sprockets_cache_store, context.environment)
+      else
+        Sprockets::SassCacheStore.new(context.environment)
       end
 
     paths  = context.environment.paths.map { |path| CompassRails::SpriteImporter.new(path) }
@@ -78,5 +78,4 @@ klass.class_eval do
       Sprockets::Cache::FileStore.new(Dir::tmpdir)
     end
   end
-end    
-
+end


### PR DESCRIPTION
I want to try out [josh/sprockets-es6](http://github.com/josh/sprockets-es6), which requires Sprockets 3 beta, so I started giving it a go here.

Right now I'm stuck at the following error:

```
couldn't find file '/usr/local/opt/rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/compass-core-1.0.3/stylesheets/compass/_css3.scss'

sprockets (3.0.0.beta.8) lib/sprockets/resolve.rb:48:in `resolve!'
sprockets (3.0.0.beta.8) lib/sprockets/context.rb:88:in `resolve'
sprockets (3.0.0.beta.8) lib/sprockets/legacy.rb:252:in `resolve_with_compat'
sprockets (3.0.0.beta.8) lib/sprockets/context.rb:111:in `depend_on'
/Users/timou/Code/github/compass-rails/lib/compass-rails/patches/sass_importer.rb:44:in `block in evaluate'
/usr/local/opt/rbenv/versions/2.2.0/lib/ruby/2.2.0/set.rb:283:in `each_key'
/usr/local/opt/rbenv/versions/2.2.0/lib/ruby/2.2.0/set.rb:283:in `each'
/Users/timou/Code/github/compass-rails/lib/compass-rails/patches/sass_importer.rb:36:in `map'
/Users/timou/Code/github/compass-rails/lib/compass-rails/patches/sass_importer.rb:36:in `evaluate'
```

Turns out that the Compass path isn't added to the load paths in `lib/sprockets/resolve.rb`. However, it's added to `Rails.application.config.sass.load_paths`, so `paths` in `compass-rails/patches/sass_importer` contains the correct load paths.

I haven't done any contributions to sprockets related stuff yet, so I'm not sure whether this is a sprockets or a compass-rails bug. Where is `Rails.application.config.sass.load_paths` initially set?
If someone could give me a hint on how to fix this or where to dig deeper, I'd be happy to try adding Sprockets 3 support.
