### PR TITLE
allow up to sass-rails 5.0.x

### DIFF
--- a/compass-rails.gemspec
+++ b/compass-rails.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'compass', '~> 1.0.0'
   gem.add_dependency 'sprockets', '< 2.13'
-  gem.add_dependency 'sass-rails', '<= 5.0.1'
+  gem.add_dependency 'sass-rails', '< 5.1'
 end


### PR DESCRIPTION
sass-rails 5.0.2 came out.  Relaxed the dependencies so this can be used with sass-rails 5.0.x. 