### PR TITLE
Updates the package name for sasy in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ For example, if you want to use susy.
 ```ruby
 # Gemfile
 gem 'compass-rails'
-gem 'compass-susy-plugin'
+gem 'susy'
 ```
 
 then run:


### PR DESCRIPTION
This package has changed from 'compass-sasy-plugin' to just 'susy'.