### PR TITLE
sass-rails changed Sass::Rails::SassTemplate so it no longer extends Spr...

### DIFF
--- a/lib/compass-rails/patches/sass_importer.rb
+++ b/lib/compass-rails/patches/sass_importer.rb
@@ -55,17 +55,27 @@ klass.class_eval do
   private
 
   def sass_importer_artiy
-    @sass_importer_artiy ||= Sprockets::SassImporter.instance_method(:initialize).arity
+    @sass_importer_artiy ||= sass_importer_class.instance_method(:initialize).arity
   end
-
 
   def sass_importer(context, path)
     case sass_importer_artiy.abs
     when 1
-      self.class.parent::SassImporter.new(path)
+      sass_importer_class.new(path)
     else
-      self.class.parent::SassImporter.new(context, path)
+      sass_importer_class.new(context, path)
     end
+  end
+
+  # if using haml-rails, self.class.parent = Haml::Filters (which doesn't have an implementation)
+  def sass_importer_class
+    @sass_importer_class ||= if defined?(self.class.parent::SassImporter)
+                               self.class.parent::SassImporter
+                             elsif defined?(Sass::Rails::SassTemplate)
+                               Sass::Rails::SassTemplate
+                             else
+                               Sprockets::SassTemplate
+                             end
   end
 
   def sprockets_cache_store

--- a/lib/compass-rails/patches/sass_importer.rb
+++ b/lib/compass-rails/patches/sass_importer.rb
@@ -55,7 +55,7 @@ klass.class_eval do
   private
 
   def sass_importer_artiy
-    @sass_importer_artiy ||= self.class.parent::SassImporter.instance_method(:initialize).arity
+    @sass_importer_artiy ||= Sprockets::SassImporter.instance_method(:initialize).arity
   end
 
 

--- a/lib/compass-rails/patches/sass_importer.rb
+++ b/lib/compass-rails/patches/sass_importer.rb
@@ -72,9 +72,9 @@ klass.class_eval do
     @sass_importer_class ||= if defined?(self.class.parent::SassImporter)
                                self.class.parent::SassImporter
                              elsif defined?(Sass::Rails::SassTemplate)
-                               Sass::Rails::SassTemplate
+                               Sass::Rails::SassImporter
                              else
-                               Sprockets::SassTemplate
+                               Sprockets::SassImporter
                              end
   end
 


### PR DESCRIPTION
...ockets::SassTemplate so calling .parent::SassImporter fails. Switched to always using Sprockets::SassImporter

Fixes this issue: https://github.com/Compass/compass-rails/issues/238
and by association: https://github.com/indirect/haml-rails/issues/77

I'm not a sprockets expert, but I think this is correct, tests pass:

Finished in 31.137002s, 0.0642 runs/s, 0.6423 assertions/s.
2 runs, 20 assertions, 0 failures, 0 errors, 0 skips