### PR TITLE
Remove sprockets dependency

### DIFF
--- a/compass-rails.gemspec
+++ b/compass-rails.gemspec
@@ -17,6 +17,5 @@ Gem::Specification.new do |gem|
   gem.license       = "MIT"
 
   gem.add_dependency 'compass', '~> 1.0.0'
-  gem.add_dependency 'sprockets', '< 2.13'
   gem.add_dependency 'sass-rails', '< 5.1'
 end

--- a/lib/compass-rails/patches/4_0.rb
+++ b/lib/compass-rails/patches/4_0.rb
@@ -13,21 +13,23 @@ Compass::Core::SassExtensions::Functions::Urls::GeneratedImageUrl.module_eval do
     generated_images_dir = Rails.root.join(generated_images_dir)
 
     sprockets_env     = options[:sprockets][:environment]
-    sprockets_trail   = sprockets_env.send(:trail)
-    sprockets_entries = sprockets_trail.instance_variable_get(:@entries) || {}
-    sprockets_stats   = sprockets_trail.instance_variable_get(:@stats) || {}
+    if sprockets_env.respond_to?(:trail, true)
+      sprockets_trail   = sprockets_env.send(:trail)
+      sprockets_entries = sprockets_trail.instance_variable_get(:@entries) || {}
+      sprockets_stats   = sprockets_trail.instance_variable_get(:@stats) || {}
 
-    if sprockets_entries.key?(generated_images_dir.to_s)
-      path = path.value
-      dir  = File.dirname(path)
+      if sprockets_entries.key?(generated_images_dir.to_s)
+        path = path.value
+        dir  = File.dirname(path)
 
-      # Delete the entries (directories) which cache the files/dirs in a directory
-      entry = generated_images_dir.join(dir).to_s
-      sprockets_entries.delete(entry)
+        # Delete the entries (directories) which cache the files/dirs in a directory
+        entry = generated_images_dir.join(dir).to_s
+        sprockets_entries.delete(entry)
 
-      # Delete the stats (file/dir info) which cache the what kind of file/dir each image is
-      stat = generated_images_dir.join(path).to_s
-      sprockets_stats.delete(stat)
+        # Delete the stats (file/dir info) which cache the what kind of file/dir each image is
+        stat = generated_images_dir.join(path).to_s
+        sprockets_stats.delete(stat)
+      end
     end
   end
 end

--- a/lib/compass-rails/patches/sass_importer.rb
+++ b/lib/compass-rails/patches/sass_importer.rb
@@ -7,11 +7,11 @@ end
 klass.class_eval do
   def evaluate(context, locals, &block)
     # Use custom importer that knows about Sprockets Caching
-    cache_store = 
-      if defined?(Sprockets::SassCacheStore)
-        Sprockets::SassCacheStore.new(context.environment)
+    cache_store =
+      if defined?(::Sprockets::SassProcessor::CacheStore)
+        ::Sprockets::SassProcessor::CacheStore.new(::Sprockets::Cache.new(sprockets_cache_store), Time.now.to_s)
       else
-        Sprockets::SassProcessor::CacheStore.new(sprockets_cache_store, context.environment)
+        ::Sprockets::SassCacheStore.new(context.environment)
       end
 
     paths  = context.environment.paths.map { |path| CompassRails::SpriteImporter.new(path) }

--- a/lib/compass-rails/railties/4_0.rb
+++ b/lib/compass-rails/railties/4_0.rb
@@ -23,11 +23,13 @@ module CompassRails
               caller.grep(%r{/sprockets/rails/task.rb}).any? && #OMG HAX - check if we're being precompiled
               Compass.configuration.generated_images_path[Compass.configuration.images_path.to_s] # if the generated images path is not in the assets images directory, we don't have to do these backflips
 
-            # Clear entries in Hike::Index for this sprite's directory.
-            # This makes sure the asset can be found by find_assets
-            index = Rails.application.assets.send(:trail).index
-            index.instance_variable_get(:@entries).delete(File.dirname(filename))
-            index.instance_variable_get(:@stats).delete(filename)
+            if Rails.application.assets.respond_to?(:trail, true)
+              # Clear entries in Hike::Index for this sprite's directory.
+              # This makes sure the asset can be found by find_assets
+              index = Rails.application.assets.send(:trail).index
+              index.instance_variable_get(:@entries).delete(File.dirname(filename))
+              index.instance_variable_get(:@stats).delete(filename)
+            end
 
             pathname      = Pathname.new(filename)
             logical_path  = pathname.relative_path_from(Pathname.new(Compass.configuration.images_path))


### PR DESCRIPTION
Since sass-rails depends on sprockets, I would like to remove sprockets dependency from `compass-rails.gemspec`.