### PR TITLE
undefined method `=~' for #<Pathname:../images/icons/facebook.png>

### DIFF
--- a/lib/compass-rails/patches/sprite_importer.rb
+++ b/lib/compass-rails/patches/sprite_importer.rb
@@ -15,7 +15,7 @@ module CompassRails
         self.class.files(uri).each do |file|
           relative_path = Pathname.new(file).relative_path_from(Pathname.new(root))
           begin
-            pathname = context.resolve(relative_path)
+            pathname = context.resolve(relative_path.to_s)
             context.depend_on_asset(pathname)
           rescue Sprockets::FileNotFound
 


### PR DESCRIPTION
When trying to make a sprite, this phenomenon occurs.

・compass-rails 3.0.0 ( a1c890628d61f62e61474de2c00dde2658251196 )
・rails 4.2.5
・sprockets 3.5.2
・sass-rails 5.0.4

To reproduce:
- To one of the rails application, add the following settings.
 - add sprite setting
 - `mkdir app/assets/fonts`
- Run: `rake assets:precompile`

See: https://github.com/tono/compass-error-case 

Fails with:
```
NoMethodError: undefined method `=~' for #<Pathname:../images/icons/facebook.png>
/works/compass-error-case/vendor/bundle/ruby/2.2.0/gems/sprockets-3.5.2/lib/sprockets/path_utils.rb:100:in `relative_path?'
/works/compass-error-case/vendor/bundle/ruby/2.2.0/gems/sprockets-3.5.2/lib/sprockets/resolve.rb:57:in `resolve!'
/works/compass-error-case/vendor/bundle/ruby/2.2.0/gems/sprockets-3.5.2/lib/sprockets/context.rb:88:in `resolve'
/works/compass-error-case/vendor/bundle/ruby/2.2.0/gems/sprockets-3.5.2/lib/sprockets/legacy.rb:255:in `resolve_with_compat'
/works/compass-error-case/vendor/bundle/ruby/2.2.0/bundler/gems/compass-rails-a1c890628d61/lib/compass-rails/patches/sprite_importer.rb:18:in `block in find'
/works/compass-error-case/vendor/bundle/ruby/2.2.0/bundler/gems/compass-rails-a1c890628d61/lib/compass-rails/patches/sprite_importer.rb:15:in `each'
/works/compass-error-case/vendor/bundle/ruby/2.2.0/bundler/gems/compass-rails-a1c890628d61/lib/compass-rails/patches/sprite_importer.rb:15:in `find'
..snip..
```

This is I think for `Sprockets::Resolve.resolve!` to `relative_path?` has been added from the `sprockets v3.0.2` ( rails/sprockets@31bba9a61f986eb0736c669305292ea95eabc847 ).