### PR TITLE
sprockets 3 compatibility

### DIFF
--- a/lib/compass-rails.rb
+++ b/lib/compass-rails.rb
@@ -42,7 +42,7 @@ module CompassRails
       @context ||= begin
         sprockets.version = ::Rails.env + "-#{sprockets.version}"
         setup_fake_rails_env_paths(sprockets)
-        context = ::Rails.application.assets.context_class
+        context = sprockets.context_class
         context.extend(::Sprockets::Helpers::IsolatedHelper)
         context.extend(::Sprockets::Helpers::RailsHelper)
         context.extend(::Sass::Rails::Railtie::SassContext)

--- a/lib/compass-rails.rb
+++ b/lib/compass-rails.rb
@@ -35,7 +35,7 @@ module CompassRails
     end
 
     def sprockets
-      @sprockets ||= ::Rails.application.assets
+      @sprockets ||= ::Rails.application.assets || ::Rails.application.config.assets
     end
 
     def context

--- a/lib/compass-rails/patches/compass.rb
+++ b/lib/compass-rails/patches/compass.rb
@@ -2,11 +2,23 @@ Compass::Core::SassExtensions::Functions::ImageSize.class_eval do
   private
 
   def image_path_for_size(image_file)
-    begin
-      file = CompassRails.sprockets.find_asset(image_file)
-      return file
-    rescue ::Sprockets::FileOutsidePaths
-      return super(image_file)
+    if ::Rails.application.config.assets.compile
+      begin
+        file = CompassRails.sprockets.find_asset(image_file)
+        return file.respond_to?(:pathname) ? file.pathname.to_s : file
+      rescue ::Sprockets::FileOutsidePaths
+        return super(image_file)
+      end
+    else
+      return image_file if File.exists?(image_file)
+
+      assets_manifest = ::Rails.application.assets_manifest
+      file = assets_manifest.assets[image_file]
+      if file
+        ::Rails.root.join("public", assets_manifest.directory, file)
+      else
+        super(image_file)
+      end
     end
   end
 end

--- a/lib/compass-rails/patches/compass.rb
+++ b/lib/compass-rails/patches/compass.rb
@@ -3,7 +3,7 @@ Compass::Core::SassExtensions::Functions::ImageSize.class_eval do
 
   def image_path_for_size(image_file)
     begin
-      file = ::Rails.application.assets.find_asset(image_file)
+      file = CompassRails.sprockets.find_asset(image_file)
       return file
     rescue ::Sprockets::FileOutsidePaths
       return super(image_file)

--- a/lib/compass-rails/patches/importer.rb
+++ b/lib/compass-rails/patches/importer.rb
@@ -8,11 +8,11 @@ module Compass
       @sass_options[:custom] = {:resolver => ::Sass::Rails::Resolver.new(CompassRails.context)}
       @sass_options[:load_paths] ||= []
       unless @sass_options[:load_paths].any? {|k| k.is_a?(::Sass::Rails::Importer) }
-        ::Rails.application.assets.paths.each do |path|
+        CompassRails.sprockets.paths.each do |path|
           next unless path.to_s =~ STYLESHEET
           Dir["#{path}/**/*"].each do |pathname|
             # args are: sprockets environment, the logical_path ex. 'stylesheets', and the full path name for the render
-            context = ::CompassRails.context.new(::Rails.application.assets, File.basename(path), Pathname.new(pathname))
+            context = ::CompassRails.context.new(CompassRails.sprockets, File.basename(path), Pathname.new(pathname))
             @sass_options[:load_paths] << ::Sass::Rails::Importer.new(context)
           end
         end


### PR DESCRIPTION
Sprockets 3 does not set ::Rails.application.assets when ::Rails.application.config.assets.compile is false. I have changed code to return ::Rails.application.config.assets instead. It returns correct assets paths.

I have also updated patched image_path_for_size for compass, it should work even with disabled config.assets.compile now.