### PR TITLE
Fix assets:precompile in Production mode when using Sprockets 3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change log
 
-## 3.0.0 - Unreleased
+## 3.0.1 - 2016-2
+### Fixed
+- Fix running rake assts:precompile to be run in production mode. Issue #257.
+
+## 3.0.0 - 2016-01-23
 ### Added
 - Added Sprockets 3 support. Issue #232, #236, #244.
 

--- a/lib/compass-rails.rb
+++ b/lib/compass-rails.rb
@@ -35,14 +35,14 @@ module CompassRails
     end
 
     def sprockets
-      @sprockets ||= ::Rails.application.assets
+      @sprockets ||= Rails.application.assets || ::Sprockets::Railtie.build_environment(Rails.application)
     end
 
     def context
       @context ||= begin
         sprockets.version = ::Rails.env + "-#{sprockets.version}"
         setup_fake_rails_env_paths(sprockets)
-        context = ::Rails.application.assets.context_class
+        context = ::CompassRails.sprockets.context_class
         context.extend(::Sprockets::Helpers::IsolatedHelper)
         context.extend(::Sprockets::Helpers::RailsHelper)
         context.extend(::Sass::Rails::Railtie::SassContext)
@@ -125,4 +125,3 @@ if defined?(::Rails)
   require "compass-rails/patches"
   require "compass-rails/railties"
 end
-

--- a/lib/compass-rails/patches/compass.rb
+++ b/lib/compass-rails/patches/compass.rb
@@ -3,7 +3,7 @@ Compass::Core::SassExtensions::Functions::ImageSize.class_eval do
 
   def image_path_for_size(image_file)
     begin
-      file = ::Rails.application.assets.find_asset(image_file)
+      file = ::CompassRails.sprockets.find_asset(image_file)
       return file
     rescue ::Sprockets::FileOutsidePaths
       return super(image_file)

--- a/lib/compass-rails/patches/importer.rb
+++ b/lib/compass-rails/patches/importer.rb
@@ -8,11 +8,11 @@ module Compass
       @sass_options[:custom] = {:resolver => ::Sass::Rails::Resolver.new(CompassRails.context)}
       @sass_options[:load_paths] ||= []
       unless @sass_options[:load_paths].any? {|k| k.is_a?(::Sass::Rails::Importer) }
-        ::Rails.application.assets.paths.each do |path|
+        ::CompassRails.sprockets.paths.each do |path|
           next unless path.to_s =~ STYLESHEET
           Dir["#{path}/**/*"].each do |pathname|
             # args are: sprockets environment, the logical_path ex. 'stylesheets', and the full path name for the render
-            context = ::CompassRails.context.new(::Rails.application.assets, File.basename(path), Pathname.new(pathname))
+            context = ::CompassRails.context.new(::CompassRails.sprockets, File.basename(path), Pathname.new(pathname))
             @sass_options[:load_paths] << ::Sass::Rails::Importer.new(context)
           end
         end

--- a/lib/compass-rails/railties/3_1.rb
+++ b/lib/compass-rails/railties/3_1.rb
@@ -25,11 +25,11 @@ module CompassRails
 
             # Clear entries in Hike::Index for this sprite's directory.
             # This makes sure the asset can be found by find_assets
-            Rails.application.assets.send(:trail).instance_variable_get(:@entries).delete(File.dirname(filename))
+            CompassRails.sprockets.send(:trail).instance_variable_get(:@entries).delete(File.dirname(filename))
 
             pathname      = Pathname.new(filename)
             logical_path  = pathname.relative_path_from(Pathname.new(Compass.configuration.images_path))
-            asset         = Rails.application.assets.find_asset(logical_path)
+            asset         = CompassRails.sprockets.find_asset(logical_path)
             target        = File.join(Rails.public_path, Rails.application.config.assets.prefix, asset.digest_path)
 
             # Adds the asset to the manifest file.

--- a/lib/compass-rails/railties/4_0.rb
+++ b/lib/compass-rails/railties/4_0.rb
@@ -25,10 +25,10 @@ module CompassRails
 
             # Clear entries in Hike::Index for this sprite's directory.
             # This makes sure the asset can be found by find_assets
-            if Rails.application.assets.respond_to?(:trail, true)
-              index = Rails.application.assets.send(:trail).index
+            if CompassRails.sprockets.respond_to?(:trail, true)
+              index = CompassRails.sprockets.send(:trail).index
             else
-              index = Rails.application.assets.index
+              index = CompassRails.sprockets.index
             end
 
             index.instance_variable_get(:@entries).delete(File.dirname(filename))
@@ -36,7 +36,7 @@ module CompassRails
 
             pathname      = Pathname.new(filename)
             logical_path  = pathname.relative_path_from(Pathname.new(Compass.configuration.images_path))
-            asset         = Rails.application.assets.find_asset(logical_path)
+            asset         = CompassRails.sprockets.find_asset(logical_path)
             target        = File.join(Rails.public_path, Rails.application.config.assets.prefix, asset.digest_path)
 
             # Adds the asset to the manifest file.

--- a/lib/compass-rails/version.rb
+++ b/lib/compass-rails/version.rb
@@ -1,3 +1,3 @@
 module CompassRails
-  VERSION = '3.0.0' unless defined?(::CompassRails::VERSION)
+  VERSION = '3.0.1' unless defined?(::CompassRails::VERSION)
 end

--- a/test/compass_rails_spec.rb
+++ b/test/compass_rails_spec.rb
@@ -36,4 +36,23 @@ describe CompassRails do
       assert_equal "public/stylesheets", project.rails_property("compass.css_dir")
     end
   end unless ENV['DEBUG_COMPILE']
+
+  it "compiles when in production mode" do
+    within_rails_app('test_railtie') do |project|
+      project.setup_asset_fixtures!
+
+      # Mimic Rails production mode
+      project.set_rails('assets.compile', false)
+
+      assert project.boots?
+
+      project.precompile!
+
+      project.compiled_stylesheet 'public/assets/application*.css' do |css|
+        refute css.empty?
+        assert_match 'body container', css
+        assert_match '.numbers-sprite-1', css
+      end
+    end
+  end
 end


### PR DESCRIPTION
The sprockets 3.0 gem has changed such that Rails.application.assets is nil in production mode (due to config.assets.compile being set to false).  This means rake assets:precompile no longer works in a production environment.

This PR changes compass-rails so it generates the sprockets environment if it finds Rails.application.assets to be nil. 

It also adds a test to ensure that precompiling runs correctly when config.assets.compile = false.