### PR TITLE
Fixed TypeError: no implicit conversion of Sprockets::Asset into String

### DIFF
--- a/lib/compass-rails/patches/compass.rb
+++ b/lib/compass-rails/patches/compass.rb
@@ -4,7 +4,7 @@ Compass::Core::SassExtensions::Functions::ImageSize.class_eval do
   def image_path_for_size(image_file)
     begin
       file = ::CompassRails.sprockets.find_asset(image_file)
-      return file
+      return (file.respond_to?(:pathname) ? file.pathname.to_s : file)
     rescue ::Sprockets::FileOutsidePaths
       return super(image_file)
     end


### PR DESCRIPTION
Fixed exception `TypeError: no implicit conversion of Sprockets::Asset into String` raised when doing `assets:precompile` in production environment when using sprockets 3.

Fixes #256.