### PR TITLE
Omit begin~end

### DIFF
--- a/lib/compass-rails/patches/compass.rb
+++ b/lib/compass-rails/patches/compass.rb
@@ -2,11 +2,9 @@ Compass::Core::SassExtensions::Functions::ImageSize.class_eval do
   private
 
   def image_path_for_size(image_file)
-    begin
-      file = ::CompassRails.sprockets.find_asset(image_file)
-      return (file.respond_to?(:pathname) ? file.pathname.to_s : file)
-    rescue ::Sprockets::FileOutsidePaths
-      return super(image_file)
-    end
+    file = ::CompassRails.sprockets.find_asset(image_file)
+    file.respond_to?(:pathname) ? file.pathname.to_s : file
+  rescue ::Sprockets::FileOutsidePaths
+    super(image_file)
   end
 end


### PR DESCRIPTION
No fixed.
However, other methods have been omitted begin~end.