### PR TITLE
fix error due to Sprockets 4 no longer handling pathnames

### DIFF
--- a/lib/compass-rails/railties/4_0.rb
+++ b/lib/compass-rails/railties/4_0.rb
@@ -35,14 +35,14 @@ module CompassRails
             index.instance_variable_get(:@stats).delete(filename)
 
             pathname      = Pathname.new(filename)
-            logical_path  = pathname.relative_path_from(Pathname.new(Compass.configuration.images_path))
+            logical_path  = pathname.relative_path_from(Pathname.new(Compass.configuration.images_path)).to_s
             asset         = CompassRails.sprockets.find_asset(logical_path)
             target        = File.join(Rails.public_path, Rails.application.config.assets.prefix, asset.digest_path)
 
             # Adds the asset to the manifest file.
 
             manifest = ActionView::Base.assets_manifest
-            manifest.assets[logical_path.to_s] = asset.digest_path
+            manifest.assets[logical_path] = asset.digest_path
 
 
             # Adds the fingerprinted asset to the public directory


### PR DESCRIPTION
I noticed the following error generating a sprite when upgrading to Sprockets 4:

```
NoMethodError: undefined method `start_with?' for #<Pathname:path/to/sprite.png>
/usr/lib/ruby/gems/2.2.0/gems/sprockets-4.0.0.beta2/lib/sprockets/uri_utils.rb:75:in `valid_asset_uri?'
/usr/lib/ruby/gems/2.2.0/gems/sprockets-4.0.0.beta2/lib/sprockets/resolve.rb:26:in `resolve'
/usr/lib/ruby/gems/2.2.0/gems/sprockets-4.0.0.beta2/lib/sprockets/base.rb:64:in `find_asset'
/usr/lib/ruby/gems/2.2.0/gems/compass-rails-3.0.2/lib/compass-rails/railties/4_0.rb:39:in `block in <class:Railtie>'
```

It appears that Sprockets is [moving away from accepting Pathnames](https://github.com/rails/sprockets/pull/24).

Unfortunately there don't appear to be any tests that exercise this code, and I wasn't able to figure out a way to get it under test with a reasonable amount of work. In order to test this I generated a sprite under the following scenarios and verified that they are identical:
* Sprockets 3.7.0 with compass-rails 3.0.2
* Sprockets 3.7.0 with this patch to compass-rails
* Sprockets 4.0.0.beta2 with this patch to compass-rails