### PR TITLE
Only add dependency if file really exist.

### DIFF
--- a/lib/compass-rails/patches/sass_importer.rb
+++ b/lib/compass-rails/patches/sass_importer.rb
@@ -41,7 +41,7 @@ klass.class_eval do
           context.depend_on(f)
         end
       else
-        context.depend_on(filename)
+        context.depend_on(filename) if File.exist?(filename)
       end
     end
 


### PR DESCRIPTION
This might be a fake filename, eg by NOT IMPORTED prefix by compass-import-once.

Fixes issue here: https://github.com/Compass/compass/issues/1951
