### PR TITLE
Update README to advise people not to start new projects with compass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # compass-rails
 
+**Don't start new projects with compass, it is no longer supported, see the [compass statement](https://github.com/Compass/compass/pull/2094)**
+
 **We Take Pull Requests!**
 
 [![Build Status](https://travis-ci.org/Compass/compass-rails.svg?branch=master)](https://travis-ci.org/Compass/compass-rails)


### PR DESCRIPTION
Compass' merged PR https://github.com/Compass/compass/pull/2094 is a clear indication that compass is no longer supported. That PR also includes alternatives.