### PR TITLE
Update Appraisals to really point to Rails 5.0

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -23,7 +23,7 @@ appraise "rails42" do
 end
 
 appraise "rails50" do
-  gem "rails", ">= 5.0.0.alpha", "< 5.1"
+  gem "rails", "~> 5.0.0"
   gem "sprockets", "< 4.0"
   gem "sass-rails", "~> 5.0"
 end

--- a/gemfiles/rails31.gemfile
+++ b/gemfiles/rails31.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "rb-fsevent", :require => false
-gem "ruby_gntp", :require => false
+gem "rb-fsevent", require: false
+gem "ruby_gntp", require: false
 gem "guard"
 gem "guard-test"
 gem "rails", "3.1.3"
@@ -16,4 +16,4 @@ group :test do
   gem "minitest"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails32.gemfile
+++ b/gemfiles/rails32.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "rb-fsevent", :require => false
-gem "ruby_gntp", :require => false
+gem "rb-fsevent", require: false
+gem "ruby_gntp", require: false
 gem "guard"
 gem "guard-test"
 gem "rails", "~> 3.2"
@@ -16,4 +16,4 @@ group :test do
   gem "minitest"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails40.gemfile
+++ b/gemfiles/rails40.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "rb-fsevent", :require => false
-gem "ruby_gntp", :require => false
+gem "rb-fsevent", require: false
+gem "ruby_gntp", require: false
 gem "guard"
 gem "guard-test"
 gem "rails", "~> 4.0.0"
@@ -16,4 +16,4 @@ group :test do
   gem "minitest"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "rb-fsevent", :require => false
-gem "ruby_gntp", :require => false
+gem "rb-fsevent", require: false
+gem "ruby_gntp", require: false
 gem "guard"
 gem "guard-test"
 gem "rails", "~> 4.2.0"
@@ -16,4 +16,4 @@ group :test do
   gem "minitest"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -2,11 +2,11 @@
 
 source "https://rubygems.org"
 
-gem "rb-fsevent", :require => false
-gem "ruby_gntp", :require => false
+gem "rb-fsevent", require: false
+gem "ruby_gntp", require: false
 gem "guard"
 gem "guard-test"
-gem "rails", ">= 5.0.0.alpha", "< 5.1"
+gem "rails", "~> 5.0.0"
 gem "sprockets", "< 4.0"
 gem "sass-rails", "~> 5.0"
 
@@ -16,4 +16,4 @@ group :test do
   gem "minitest"
 end
 
-gemspec :path => "../"
+gemspec path: "../"


### PR DESCRIPTION
It used to have the constraints `>= 5.0.0.alpha` and `< 5.1`, and the version `5.1.0.rc2` is technically considered to be `< 5.1.0`, so bundler failed to pick up the right Rails version (in this case it picked up `5.1.0.rc1` instead of `5.0.x`). This commit updates the Appraisals file to be more precise in terms of version constraints.

Also, the appraisal gem auto-updated the hash syntax. This should be fine as it is just a syntax change. Let me know if there should be a separate commit for it.