### PR TITLE
Do not test against combinations of too new Rubies and old Rails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,19 @@ gemfile:
   - gemfiles/rails42.gemfile
   - gemfiles/rails50.gemfile
 matrix:
+  exclude:
+    - rvm: 2.4.0
+      gemfile: gemfiles/rails31.gemfile
+    - rvm: 2.4.0
+      gemfile: gemfiles/rails32.gemfile
+    - rvm: 2.4.0
+      gemfile: gemfiles/rails40.gemfile
+    - rvm: ruby-head
+      gemfile: gemfiles/rails31.gemfile
+    - rvm: ruby-head
+      gemfile: gemfiles/rails32.gemfile
+    - rvm: ruby-head
+      gemfile: gemfiles/rails40.gemfile
   fast_finish: true
   allow_failures:
     - rvm: ruby-head


### PR DESCRIPTION
The build for Ruby 2.4 and Rails 4.0 was failing but Rails 4.0 doesn't officially support Ruby 2.4.0. This is because when Ruby 2.4.0 was released, the only major versions that were being maintained at that point were 4.2 and 5.0. I think it should be ok to not test the combinations of new Rubies and old Rails.

If you merge https://github.com/Compass/compass-rails/pull/276 and this PR. the build will be green.