### PR TITLE
Use `module_parent` instead of deprecated `parent`

### DIFF
--- a/lib/compass-rails/patches/sass_importer.rb
+++ b/lib/compass-rails/patches/sass_importer.rb
@@ -69,8 +69,8 @@ klass.class_eval do
 
   # if using haml-rails, self.class.parent = Haml::Filters (which doesn't have an implementation)
   def sass_importer_class
-    @sass_importer_class ||= if defined?(self.class.parent::SassImporter)
-                               self.class.parent::SassImporter
+    @sass_importer_class ||= if defined?(self.class.respond_to?(:module_parent) ? self.class.module_parent::SassImporter : self.class.parent::SassImporter)
+                               self.class.respond_to?(:module_parent) ? self.class.module_parent::SassImporter : self.class.parent::SassImporter
                              elsif defined?(Sass::Rails::SassTemplate)
                                Sass::Rails::SassImporter
                              else


### PR DESCRIPTION
Module#parent_name is deprecated in Rails 6.0.
Ref: rails/rails#34051