### PR TITLE
Prefer module_parent over Module#parent when possible

### DIFF
--- a/lib/compass-rails/patches/sass_importer.rb
+++ b/lib/compass-rails/patches/sass_importer.rb
@@ -67,10 +67,11 @@ klass.class_eval do
     end
   end
 
-  # if using haml-rails, self.class.parent = Haml::Filters (which doesn't have an implementation)
+  # if using haml-rails, self.class.module_parent = Haml::Filters (which doesn't have an implementation)
   def sass_importer_class
-    @sass_importer_class ||= if defined?(self.class.parent::SassImporter)
-                               self.class.parent::SassImporter
+    module_parent = self.class.respond_to?(:module_parent) ? self.class.module_parent : self.class.parent
+    @sass_importer_class ||= if defined?(module_parent::SassImporter)
+                               module_parent::SassImporter
                              elsif defined?(Sass::Rails::SassTemplate)
                                Sass::Rails::SassImporter
                              else


### PR DESCRIPTION
This removes the Rails 6 deprecation warning and resolves https://github.com/Compass/compass-rails/issues/283

This uses `self.class.respond_to?(:module_parent)` approach. Another option is to ask for Rails or ActiveSupport version explicitly with:

`Rails::VERSION::MAJOR >= 6` or `ActiveSupport::VERSION::STRING < "6.0"` , depends on how we decide to set expectations regarding gems (e.g. does this primarily depend on rails or just activesupport?)