### PR TITLE
Address Rails 6.1 deprecation warning about Module::parent

### DIFF
--- a/lib/compass-rails/patches/sass_importer.rb
+++ b/lib/compass-rails/patches/sass_importer.rb
@@ -67,10 +67,11 @@ klass.class_eval do
     end
   end
 
-  # if using haml-rails, self.class.parent = Haml::Filters (which doesn't have an implementation)
+  # if using haml-rails, self.class.module_parent = Haml::Filters (which doesn't have an implementation)
   def sass_importer_class
-    @sass_importer_class ||= if defined?(self.class.parent::SassImporter)
-                               self.class.parent::SassImporter
+    @module_parent ||= self.class.respond_to?(:module_parent) ? self.class.module_parent : self.class.parent
+    @sass_importer_class ||= if defined?(@module_parent::SassImporter)
+                               @module_parent::SassImporter
                              elsif defined?(Sass::Rails::SassTemplate)
                                Sass::Rails::SassImporter
                              else

--- a/lib/compass-rails/version.rb
+++ b/lib/compass-rails/version.rb
@@ -1,3 +1,3 @@
 module CompassRails
-  VERSION = '4.0.0' unless defined?(::CompassRails::VERSION)
+  VERSION = '4.0.1' unless defined?(::CompassRails::VERSION)
 end


### PR DESCRIPTION
Adapted from [this PR on the deprecated root project](https://github.com/Compass/compass-rails/pull/284).